### PR TITLE
fix seeding

### DIFF
--- a/lib/foreman_rescue/engine.rb
+++ b/lib/foreman_rescue/engine.rb
@@ -46,7 +46,7 @@ module ForemanRescue
 
     rake_tasks do
       Rake::Task['db:seed'].enhance do
-        ForemanOmaha::Engine.load_seed
+        ForemanRescue::Engine.load_seed
       end
     end
 


### PR DESCRIPTION
After installation of the plugin db:seed is broken when not also having Omaha installed, what is probably only a copy and paste error.