### PR TITLE
Fixing PXEGrub2 Template selection in rescue system settings page

### DIFF
--- a/app/models/setting/rescue.rb
+++ b/app/models/setting/rescue.rb
@@ -15,7 +15,7 @@ class Setting
         set('rescue_pxegrub2_tftp_template',
             N_('PXEGrub2 template used when booting rescue system'),
             '', N_('PXEGrub2 rescue template'), nil,
-            :collection => proc { Setting::Rescue.templates('PXEGrub 2') })
+            :collection => proc { Setting::Rescue.templates('PXEGrub2') })
       ]
     end
 


### PR DESCRIPTION
I noticed that in the Foreman settings page I cannot select a PXEGrub2 template. I only see snippets in the drop down field but no PXEGrub2 templates. 

After digging in the code, I found a small error / typo which is responsible for this error. I have fixed that locally and verified that my fix works. So here is the PR with my fix. 